### PR TITLE
Lazy permissions fix#38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tmp/*
 .sass-cache
 .idea/
 coverage
+tags
+*.swp

--- a/app/views/curate/collections/new.html.erb
+++ b/app/views/curate/collections/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_header do %>
   <h1><%= title_for_new_form(@add_to_profile) %></h1>
 <% end %>
+<% @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
 <%= render 'form' %>

--- a/app/views/curation_concern/generic_works/new.html.erb
+++ b/app/views/curation_concern/generic_works/new.html.erb
@@ -10,5 +10,5 @@
 </p>
 
 <% end %>
-
+<% curation_concern.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
 <%= render 'form' %>

--- a/spec/features/article_spec.rb
+++ b/spec/features/article_spec.rb
@@ -4,6 +4,12 @@ describe 'Creating a article' do
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_curation_concern_article_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+ 
   describe 'with a related link' do
     it "should allow me to attach the link on the create page" do
       login_as(user)

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe "Showing and creating Collections" do
   let(:user) { FactoryGirl.create(:user) }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_collection_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+
   it "should create them" do
     login_as(user)
     visit root_path

--- a/spec/features/dataset_spec.rb
+++ b/spec/features/dataset_spec.rb
@@ -4,6 +4,12 @@ describe 'Creating a dataset' do
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_curation_concern_dataset_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+
   describe 'with a related link' do
     it "should allow me to attach the link on the create page" do
       login_as(user)

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -80,13 +80,13 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
 
       visit new_curation_concern_generic_work_path
       create_generic_work(
-        'Visibility' => 'visibility_restricted',
+        'Visibility' => 'visibility_open',
         'I Agree' => true,
         'Title' => ''
       )
 
-      expect(page).to have_checked_field('visibility_restricted')
-      expect(page).to_not have_checked_field('visibility_open')
+      expect(page).to have_checked_field('visibility_open')
+      expect(page).to_not have_checked_field('visibility_restricted')
     end
 
     it "a public item with future embargo is not visible today but is in the future" do

--- a/spec/features/etd_spec.rb
+++ b/spec/features/etd_spec.rb
@@ -4,6 +4,12 @@ describe 'Creating an etd' do
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_curation_concern_etd_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+
   it "should allow me to attach the link on the create page" do
     login_as(user)
     visit root_path

--- a/spec/features/generic_work_spec.rb
+++ b/spec/features/generic_work_spec.rb
@@ -9,6 +9,12 @@ describe 'Creating a generic work' do
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_curation_concern_generic_work_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+
   describe 'with a related link' do
     it "should allow me to attach the link on the create page" do
       login_as(user)

--- a/spec/features/image_spec.rb
+++ b/spec/features/image_spec.rb
@@ -4,6 +4,12 @@ describe 'Creating an image' do
   let(:person) { FactoryGirl.create(:person_with_user) }
   let(:user) { person.user }
 
+  it 'defaults to open visibility' do
+    login_as(user)
+    visit new_curation_concern_image_path
+    expect(page).to have_checked_field('visibility_open')
+  end
+
   it "should allow me to attach the link on the create page" do
     login_as(user)
     visit root_path


### PR DESCRIPTION
I've run the full test suite a few times after making all of these changes, and I'm having random various tests inconsistently fail. Any idea what's causing this?

Otherwise everything seems good. Only thing missing from the tests is the Document type, but the Document model inherits directly from Generic Work, so I think it's a very low risk omission. Let me know if you'd prefer that I add a test there.

Otherwise, after this pull request is merged, I'll add a page to the wiki documenting this change.
