### PR TITLE
Force devise to 3.2.x - was getting an error on 3.3.0

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'simple_form', '~> 3.0.1'
   s.add_dependency 'active_attr'
   s.add_dependency 'bootstrap-datepicker-rails'
-  s.add_dependency 'devise'
+  s.add_dependency 'devise', "~> 3.2.0"
   s.add_dependency "devise-guests", "~> 0.3"
   s.add_dependency 'browser'
   s.add_dependency 'breadcrumbs_on_rails'
@@ -59,7 +59,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner', '< 1.1.0'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'vcr'
-  s.add_development_dependency 'devise'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'test_after_commit'
 end


### PR DESCRIPTION
Was getting error below on generated app, which was running devise 3.3.0, while signing up a new user

```
undefined method `password_length' for #<Class:0x007fb2da9b3ce8>

Rails.root: /Users/vanmiljf/development/gems/curate_fork/spec/internal
Application Trace | Framework Trace | Full Trace

devise (3.3.0) app/controllers/devise/registrations_controller.rb:10:in `new'
actionpack (4.0.5) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
actionpack (4.0.5) lib/abstract_controller/base.rb:189:in `process_action'
actionpack (4.0.5) lib/action_controller/metal/rendering.rb:10:in `process_action'
actionpack (4.0.5) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
activesupport (4.0.5) lib/active_support/callbacks.rb:463:in `_run__3192786528338014093__process_action__callbacks'
activesupport (4.0.5) lib/active_support/callbacks.rb:80:in `run_callbacks'
actionpack (4.0.5) lib/abstract_controller/callbacks.rb:17:in `process_action'
actionpack (4.0.5) lib/action_controller/metal/rescue.rb:29:in `process_action'
actionpack (4.0.5) lib/action_controller/metal/instrumentation.rb:31:in `block in process_action'
activesupport (4.0.5) lib/active_support/notifications.rb:159:in `block in instrument'
activesupport (4.0.5) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
activesupport (4.0.5) lib/active_support/notifications.rb:159:in `instrument'
actionpack (4.0.5) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
actionpack (4.0.5) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
activerecord (4.0.5) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
actionpack (4.0.5) lib/abstract_controller/base.rb:136:in `process'
actionpack (4.0.5) lib/abstract_controller/rendering.rb:44:in `process'
actionpack (4.0.5) lib/action_controller/metal.rb:195:in `dispatch'
actionpack (4.0.5) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
actionpack (4.0.5) lib/action_controller/metal.rb:231:in `block in action'
actionpack (4.0.5) lib/action_dispatch/routing/route_set.rb:80:in `call'
actionpack (4.0.5) lib/action_dispatch/routing/route_set.rb:80:in `dispatch'
actionpack (4.0.5) lib/action_dispatch/routing/route_set.rb:48:in `call'
actionpack (4.0.5) lib/action_dispatch/routing/mapper.rb:44:in `call'
actionpack (4.0.5) lib/action_dispatch/journey/router.rb:71:in `block in call'
actionpack (4.0.5) lib/action_dispatch/journey/router.rb:59:in `each'
actionpack (4.0.5) lib/action_dispatch/journey/router.rb:59:in `call'
actionpack (4.0.5) lib/action_dispatch/routing/route_set.rb:674:in `call'
warden (1.2.3) lib/warden/manager.rb:35:in `block in call'
warden (1.2.3) lib/warden/manager.rb:34:in `catch'
warden (1.2.3) lib/warden/manager.rb:34:in `call'
rack (1.5.2) lib/rack/etag.rb:23:in `call'
rack (1.5.2) lib/rack/conditionalget.rb:25:in `call'
rack (1.5.2) lib/rack/head.rb:11:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/flash.rb:241:in `call'
rack (1.5.2) lib/rack/session/abstract/id.rb:225:in `context'
rack (1.5.2) lib/rack/session/abstract/id.rb:220:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/cookies.rb:486:in `call'
activerecord (4.0.5) lib/active_record/query_cache.rb:36:in `call'
activerecord (4.0.5) lib/active_record/connection_adapters/abstract/connection_pool.rb:626:in `call'
activerecord (4.0.5) lib/active_record/migration.rb:373:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
activesupport (4.0.5) lib/active_support/callbacks.rb:373:in `_run__1985408232081714872__call__callbacks'
activesupport (4.0.5) lib/active_support/callbacks.rb:80:in `run_callbacks'
actionpack (4.0.5) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/reloader.rb:64:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/remote_ip.rb:76:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
railties (4.0.5) lib/rails/rack/logger.rb:38:in `call_app'
railties (4.0.5) lib/rails/rack/logger.rb:20:in `block in call'
activesupport (4.0.5) lib/active_support/tagged_logging.rb:68:in `block in tagged'
activesupport (4.0.5) lib/active_support/tagged_logging.rb:26:in `tagged'
activesupport (4.0.5) lib/active_support/tagged_logging.rb:68:in `tagged'
railties (4.0.5) lib/rails/rack/logger.rb:20:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/request_id.rb:21:in `call'
rack (1.5.2) lib/rack/methodoverride.rb:21:in `call'
rack (1.5.2) lib/rack/runtime.rb:17:in `call'
activesupport (4.0.5) lib/active_support/cache/strategy/local_cache.rb:83:in `call'
rack (1.5.2) lib/rack/lock.rb:17:in `call'
actionpack (4.0.5) lib/action_dispatch/middleware/static.rb:64:in `call'
rack (1.5.2) lib/rack/sendfile.rb:112:in `call'
railties (4.0.5) lib/rails/engine.rb:511:in `call'
railties (4.0.5) lib/rails/application.rb:97:in `call'
rack (1.5.2) lib/rack/lock.rb:17:in `call'
rack (1.5.2) lib/rack/content_length.rb:14:in `call'
rack (1.5.2) lib/rack/handler/webrick.rb:60:in `service'
/Users/vanmiljf/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/webrick/httpserver.rb:138:in `service'
/Users/vanmiljf/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/webrick/httpserver.rb:94:in `run'
/Users/vanmiljf/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/webrick/server.rb:295:in `block in start_thread'
```
