### PR TITLE
Adds clamav scan to browse_everything resources.

### DIFF
--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -65,14 +65,15 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
 
   def create
     curation_concern.batch = parent
-    if attributes_for_actor["file"]
+    if attributes_for_actor["file"] || attributes_for_actor["cloud_resources"] 
       if actor.create
         curation_concern.update_parent_representative_if_empty(parent)
         respond_with([:curation_concern, parent])
       else
+        flash[:error] = "The file that you attempted to upload had a  virus.  Please select another file."
         respond_with([:curation_concern, curation_concern]) { |wants|
           wants.html { render 'new', status: :unprocessable_entity }
-        }
+         }
       end
     else
       respond_with([:curation_concern, curation_concern]) { |wants|

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -38,8 +38,9 @@ class CurationConcern::GenericWorksController < CurationConcern::BaseController
       after_create_response
     else
       setup_form
+      flash[:error] = "A virus/error was found in one of the uploaded files.  The file was not uploaded, but the work was created."
       respond_with([:curation_concern, curation_concern]) do |wants|
-        wants.html { render 'new', status: :unprocessable_entity }
+        wants.html { render 'show', status: :unprocessable_entity }
       end
     end
   end

--- a/app/services/curation_concern/generic_file_actor.rb
+++ b/app/services/curation_concern/generic_file_actor.rb
@@ -2,8 +2,8 @@ module CurationConcern
   class GenericFileActor < CurationConcern::BaseActor
 
     def create
-      super && update_file  && download_create_cloud_resources
-    end
+       download_create_cloud_resources && update_file && super 
+   end
 
     def update
       super && update_file  && download_create_cloud_resources
@@ -52,7 +52,9 @@ module CurationConcern
     def update_cloud_resource(cloud_resource)
       return true if ! cloud_resource.present?
       file_path=cloud_resource.download_content_from_host
-      if file_path.present? && File.exists?(file_path) && !File.zero?(file_path)
+      clam = ClamAV.instance
+      scan_result = clam.scanfile(file_path)
+      if (scan_result.is_a? Fixnum) && file_path.present? && File.exists?(file_path) && !File.zero?(file_path)
         cloud_resource = File.open(file_path)
         title = attributes[:title]
         title ||= File.basename(cloud_resource)

--- a/app/services/curation_concern/generic_work_actor.rb
+++ b/app/services/curation_concern/generic_work_actor.rb
@@ -117,7 +117,11 @@ module CurationConcern
     def attach_cloud_resource(cloud_resource)
       return true if ! cloud_resource.present?
       file_path=cloud_resource.download_content_from_host
-      if  valid_file?(file_path)
+      clam = ClamAV.instance
+      scan_result = clam.scanfile(file_path)
+#     if (scan_result.is_a? Fixnum) && file_path.present? && File.exists?(file_path) && !File.zero?(file_path)
+
+      if  valid_file?(file_path) && (scan_result.is_a? Fixnum)
         cloud_resource = File.open(file_path)
         generic_file = GenericFile.new
         generic_file.file = cloud_resource

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -75,7 +75,7 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
       page.assert_selector('.main-header h2', "Describe Your Work")
     end
 
-    it 'remembers generic_work inputs when data was invalid' do
+    it 'sends generic_work error alert when data was invalid' do
       login_as(user)
 
       visit new_curation_concern_generic_work_path
@@ -85,8 +85,12 @@ describe 'end to end behavior', FeatureSupport.options(describe_options) do
         'Title' => ''
       )
 
-      expect(page).to have_checked_field('visibility_open')
-      expect(page).to_not have_checked_field('visibility_restricted')
+      within('.alert.error') do
+        page.should have_content('A virus/error was found in one of the uploaded files.')
+      end
+
+#      expect(page).to have_checked_field('visibility_open')
+#      expect(page).to_not have_checked_field('visibility_restricted')
     end
 
     it "a public item with future embargo is not visible today but is in the future" do

--- a/spec/features/proxy_deposit_spec.rb
+++ b/spec/features/proxy_deposit_spec.rb
@@ -36,9 +36,8 @@ describe 'Proxy Deposit' do
       choose('Visible to the world.')
       check("I have read and accept the contributor license agreement")
       click_button("Create Article")
+      expect(page).to have_selector('#article_owner', text: user.name)
     end
-
-    page.should have_content(user.name)
   end
 
   it 'auto-selects proxy as contributor when Myself is selected as owner' do

--- a/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
+++ b/spec/support/shared/shared_examples_is_a_curation_concern_controller.rb
@@ -89,7 +89,7 @@ shared_examples 'is_a_curation_concern_controller' do |curation_concern_class, o
       it 'renders the form' do
         controller.actor = double(:create => false)
         post :create, accept_contributor_agreement: "accept"
-        expect(response).to render_template('new')
+        expect(response).to render_template('show')
       end
     end
   end


### PR DESCRIPTION
Integrates browse_everything and clamav for curate_uc app.

Modifies generic_file_controller and generic_works_controller.
Modifies generic_file_actor and generic_works_actor.
Modifies spec test to account for differnet rendering option
on virus discovery.
