### PR TITLE
Remove "A PDF is preferred" from datasets and generic works forms

### DIFF
--- a/app/views/curation_concern/articles/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/articles/_form_files_and_links.html.erb
@@ -1,0 +1,28 @@
+<% unless curation_concern.persisted? %>
+  <fieldset id="work-contents">
+    <div class="row with-headroom">
+      <div class="span12">
+        <legend>
+          Add Your Content
+        </legend>
+
+        <p class="help-block">
+          The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file <em>or</em> a URL.
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <fieldset class="span5">
+        <%= f.input :files, as: :file, label: 'Upload a file', hint: 'A PDF is preferred.'%>
+      </fieldset>
+
+      <strong class="span1 field-choice">OR</strong>
+
+      <fieldset class="span6">
+        <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
+      </fieldset>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/curation_concern/datasets/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/datasets/_form_files_and_links.html.erb
@@ -1,0 +1,28 @@
+<% unless curation_concern.persisted? %>
+  <fieldset id="work-contents">
+    <div class="row with-headroom">
+      <div class="span12">
+        <legend>
+          Add Your Content
+        </legend>
+
+        <p class="help-block">
+          The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file <em>or</em> a URL.
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <fieldset class="span5">
+        <%= f.input :files, as: :file, label: 'Upload a file' %>
+      </fieldset>
+
+      <strong class="span1 field-choice">OR</strong>
+
+      <fieldset class="span6">
+        <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
+      </fieldset>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/curation_concern/documents/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/documents/_form_files_and_links.html.erb
@@ -1,0 +1,28 @@
+<% unless curation_concern.persisted? %>
+  <fieldset id="work-contents">
+    <div class="row with-headroom">
+      <div class="span12">
+        <legend>
+          Add Your Content
+        </legend>
+
+        <p class="help-block">
+          The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file <em>or</em> a URL.
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <fieldset class="span5">
+        <%= f.input :files, as: :file, label: 'Upload a file', hint: 'A PDF is preferred.'%>
+      </fieldset>
+
+      <strong class="span1 field-choice">OR</strong>
+
+      <fieldset class="span6">
+        <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
+      </fieldset>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/curation_concern/generic_works/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/generic_works/_form_files_and_links.html.erb
@@ -1,0 +1,28 @@
+<% unless curation_concern.persisted? %>
+  <fieldset id="work-contents">
+    <div class="row with-headroom">
+      <div class="span12">
+        <legend>
+          Add Your Content
+        </legend>
+
+        <p class="help-block">
+          The subject of your <%= curation_concern.human_readable_type.downcase %> can either be a file <em>or</em> a URL.
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <fieldset class="span5">
+        <%= f.input :files, as: :file, label: 'Upload a file' %>
+      </fieldset>
+
+      <strong class="span1 field-choice">OR</strong>
+
+      <fieldset class="span6">
+        <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
+      </fieldset>
+    </div>
+  </fieldset>
+<% end %>


### PR DESCRIPTION
Articles and documents inherit from generic works.  So I had to include
partials for articles and documents even though they did not change.
