### PR TITLE
Pin mini_magick to version < 4.0 to fix failing tests

### DIFF
--- a/curate.gemspec
+++ b/curate.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'hydra-batch-edit', '~> 1.1.1'
   s.add_dependency 'hydra-collections', '~> 1.3.0'
   s.add_dependency 'morphine'
-  s.add_dependency 'mini_magick'
+  s.add_dependency 'mini_magick', '~> 3.8'
   s.add_dependency 'simple_form', '~> 3.0.1'
   s.add_dependency 'active_attr'
   s.add_dependency 'bootstrap-datepicker-rails'


### PR DESCRIPTION
Tests fail under both ruby 2.0 and 2.1.x when using mini_magick 4.0.  Pinning to 3.8 fixes.
