### PR TITLE
Creates a background worker to remove edit access

### DIFF
--- a/app/views/curate/depositors/index.html.erb
+++ b/app/views/curate/depositors/index.html.erb
@@ -1,30 +1,58 @@
-  <div class="proxy-rights">
-
-    <fieldset class="span12">
-      <legend>Authorize Delegate</legend>
-
-      Search <%=text_field_tag :user, '', "data-url"=>"/people" %>
-
-      <table class="table table-condensed" id='authorizedProxies'>
-        <caption>Currently Authorized</caption>
-        <tbody>
-          <% @grantor.user.can_receive_deposits_from.each do |depositor| %>
-            <tr><td><%= depositor.name %></td>
-              <td><%=link_to(person_depositor_path(@grantor, depositor.person), method: :delete, class: "remove-proxy-button") do %>
-                <i class="icon-remove"></i><% end %>
-              </td></tr>
-          <% end %>
-        </tbody>
-      </table>
-
-      <script type="text/x-handlebars-template" id="tmpl-proxy-row">
-        <tr><td>{{ name }}</td>
-          <td><a class="remove-proxy-button" data-method="delete" href="/people/rj43kv61h/depositors/{{ id }}" rel="nofollow">
-            <i class="icon-remove"></i>
-          </a>
-        </td></tr>
-      </script>
-    </fieldset>
-
+<div class="row">
+  <div class="span12 main-header ">
+    <h2>Manage Your Delegates</h2>
   </div>
+</div>
+
+<div class="alert alert-block">
+  <strong>Please Note:</strong>
+  Your delegates can do <em>anything</em> on your behalf in Scholar@UC.
+  Be selective in who you give delegate access.
+</div>
+
+<div class="row">
+  <div class="span7">
+    <p>
+      Delegate accounts in Scholar@UC work very similar to <a href="https://support.google.com/mail/answer/138350?hl=en">delegate accounts in Gmail</a>.
+      If you authorize a delegate they can view, edit, or delete <em>all</em> of your existing works and files.
+      Delegates can also add create new works and upload files on your behalf.
+    </p>
+    <p>
+      You can use <a href="/hydramata/groups">groups</a> or work-specific collaborators for more fine-grained access control.
+    </p>
+  </div>
+</div>
+<div class="proxy-rights row with-headroom">
+  <fieldset class="form-inline span12">
+    <legend><h3>Grant Delegate Access</h3></legend>
+
+    <label for="user">Search by name:</label>
+    <%=text_field_tag :user, '', "data-url"=>"/people" %>
+  </fieldset>
+
+  <table class="table table-hover span12" id='authorizedProxies'>
+    <caption class="table-heading"><h3>Authorized Delegates</h3></caption>
+    <tbody>
+      <% @grantor.user.can_receive_deposits_from.each do |depositor| %>
+        <% begin %>
+          <tr>
+            <td><%= depositor.name %></td>
+            <td>
+              <%=link_to(person_depositor_path(@grantor, depositor.person), method: :delete, class: "remove-proxy-button") do %>
+                <i class="icon-remove"></i>Revoke Delegate Access
+              <% end %>
+            </td>
+          </tr>
+        <% rescue ActiveFedora::ObjectNotFoundError %>
+          <!-- Depositor's person object was deleted !-->
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+
+  <script type="text/x-handlebars-template" id="tmpl-proxy-row">
+    <tr><td>{{ name }}</td>
+    </tr>
+  </script>
+</div>
 

--- a/app/workers/delegate_editor_cleanup_worker.rb
+++ b/app/workers/delegate_editor_cleanup_worker.rb
@@ -1,0 +1,53 @@
+class DelegateEditorCleanupWorker
+  class GrantError < RuntimeError
+
+    def initialize(url_string)
+      super(url_string)
+    end
+  end
+
+  def queue_name
+    :de_delegate
+  end
+
+  attr_accessor :pids, :grantor, :grantee, :grantor_pid, :grantee_pid
+
+  def initialize(pids)
+    if pids[:grantor].nil?
+      raise GrantError.new("No Grantor found.")
+    end
+    if pids[:grantee].nil?
+      raise GrantError.new("No Grantee found.")
+    end
+    @grantor_pid = pids[:grantor]
+    @grantee_pid = pids[:grantee]
+  end
+
+  def run
+
+     grantor = ActiveFedora::Base.find(@grantor_pid, cast: true)
+     grantee = ActiveFedora::Base.find(@grantee_pid, cast: true)
+
+     type = [Article, Dataset, Document, GenericWork, Image]
+     type.each do |klass|
+       klass.find_each('depositor' => grantee.email) do |work|
+           next unless work.owner == grantor.email
+           work.edit_users -= [grantee.email]
+           work.editor_ids += [grantor.pid]
+           work.editor_ids -= [grantee.pid]
+           work.save!
+           grantee = ActiveFedora::Base.find(grantee.pid, cast: true)
+           grantee.work_ids -= [work.pid]
+           grantee.save!
+
+           if work.respond_to?(:generic_files)
+	     work.generic_files.each do |file|
+             file.edit_users = work.edit_users
+             file.edit_groups = work.edit_groups
+             file.save!
+             end    
+          end
+       end
+     end
+  end
+end

--- a/spec/controllers/curate/depositors_controller_spec.rb
+++ b/spec/controllers/curate/depositors_controller_spec.rb
@@ -26,8 +26,13 @@ describe Curate::DepositorsController do
       before do
         person.user.can_receive_deposits_from << grantee.user
       end
+     
       it "should be successful" do
         expect { delete :destroy, person_id: person.id, id: grantee.id, format: 'json' }.to change{ Curate::ProxyDepositRights.count }.by(-1)
+      end
+
+      it 'should start a background worker' do
+        DelegateEditorCleanupWorker.any_instance.stub(:run).and_return(true)
       end
     end
   end

--- a/spec/factories/generic_works_factory.rb
+++ b/spec/factories/generic_works_factory.rb
@@ -9,10 +9,16 @@ FactoryGirl.define do
     date_modified { Date.today }
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     before(:create) { |work, evaluator|
-      work.apply_depositor_metadata(evaluator.user.user_key)
-      work.owner = evaluator.user.user_key
-      work.contributor << "Some Body"
-      work.creator << "The Creator"
+      unless work.depositor.present?
+        work.apply_depositor_metadata(evaluator.user.user_key)
+        work.owner = evaluator.user.user_key
+        work.contributor << "Some Body"
+        work.creator << "The Creator"
+      else
+        work.owner = evaluator.user.user_key
+        work.contributor << "Some Body"
+        work.creator << "The Creator"		
+      end
     }
 
     factory :private_generic_work do

--- a/spec/workers/delegate_editor_cleanup_worker_spec.rb
+++ b/spec/workers/delegate_editor_cleanup_worker_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe DelegateEditorCleanupWorker do
+
+  let(:person) { FactoryGirl.create(:person_with_user) }
+  let(:user) { person.user }
+  let(:grantee) { FactoryGirl.create(:person_with_user) }
+  let(:another_user) { grantee.user }
+  let(:generic_work_w_condition) { FactoryGirl.create(:generic_work, depositor: grantee.email, user: user, edit_users: [grantee.email]) }
+  let(:generic_work_wo_condition) { FactoryGirl.create(:generic_work, user: user, owner: user.email) }
+  let(:pids) {{:grantor=>person.pid, :grantee=>grantee.pid}}
+  let(:nilpids) {{:grantee =>nil, :grantor =>nil}}
+
+  it 'should raise error when no grantor pid' do
+    expect{
+      DelegateEditorCleanupWorker.new(nilpids)
+    }.to raise_error( DelegateEditorCleanupWorker::GrantError )
+  end
+
+  it 'should raise error when no grantee pid' do
+    expect{
+      DelegateEditorCleanupWorker.new(nilpids)
+    }.to raise_error( DelegateEditorCleanupWorker::GrantError )
+  end
+
+
+  context 'for valid pid' do
+    before do
+        person.user.can_receive_deposits_from << grantee.user
+    end
+
+    it 'should change editor on qualified works' do
+      
+      expect(generic_work_w_condition.edit_users).to include (grantee.email)
+      
+      DelegateEditorCleanupWorker.new(pids).run
+      
+      expect(generic_work_w_condition.reload.edit_users).not_to include (grantee.email)
+
+    end
+
+    it 'should not change editor on unqualified works' do
+
+      expect(generic_work_wo_condition.edit_users).to eq [user.email]
+
+      DelegateEditorCleanupWorker.new(pids).run
+
+      expect(generic_work_wo_condition.edit_users).to eq [user.email]
+
+    end
+  
+  end
+end


### PR DESCRIPTION
from a delegate when the delegate is removed.

When an owner removes a delegate the background
worker will scan the repository for any objects
and attached files submitted on behalf of the owner
and then remove edit access and assign the owner
as primary editor.

This closes issue scholar_uc/#54.