### PR TITLE
Moves apply_access_permissions call from base actor to generic_works_act...

### DIFF
--- a/app/helpers/hydramata/solr_helper.rb
+++ b/app/helpers/hydramata/solr_helper.rb
@@ -31,11 +31,11 @@ module Hydramata::SolrHelper
         }
 
         if group_query.present?
-          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND (#{group_query})) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
+          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND (#{group_query})) OR (embargo_release_date_dtsi:[NOW TO *] AND edit_access_person_ssim:#{current_user.email})"
 
         # User doesn't have groups to query
         else
-          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND depositor_tesim:#{current_user.email})"
+          embargo_query = "(*:* NOT embargo_release_date_dtsi:[NOW TO *]) OR (embargo_release_date_dtsi:[NOW TO *] AND edit_access_person_ssim:#{current_user.email})"
 
         end
       end

--- a/app/services/curation_concern/base_actor.rb
+++ b/app/services/curation_concern/base_actor.rb
@@ -35,6 +35,7 @@ module CurationConcern
       apply_depositor_metadata
       apply_owner_metadata
       apply_deposit_date
+      apply_delegates_as_editor
     end
 
     def apply_update_data_to_curation_concern
@@ -72,10 +73,18 @@ module CurationConcern
     # Grants edit access to the owner.
     # This also deletes the owner key from the attributes so that it isn't
     # set again later when apply_save_data_to_curation_concern is called.
+
     def apply_owner_metadata
       owner = owner_from_attributes || user
       curation_concern.edit_users += [owner.user_key]
       curation_concern.owner = owner.user_key
+    end
+
+    def apply_delegates_as_editor
+      owner = owner_from_attributes || user
+      user.can_receive_deposits_from.each do |delegate|
+        curation_concern.edit_users += [delegate.user_key]        
+      end
     end
 
     def owner_from_attributes

--- a/app/services/curation_concern/base_actor.rb
+++ b/app/services/curation_concern/base_actor.rb
@@ -54,20 +54,11 @@ module CurationConcern
       curation_concern.apply_doi_assignment_strategy do |*|
         curation_concern.save
       end
-      apply_access_permissions
-    end
-
-    def apply_access_permissions
-      Sufia.queue.push(AccessPermissionsCopyWorker.new(pid_for_object_to_copy_permissions_from))
     end
 
     def apply_save_data_to_curation_concern
       curation_concern.attributes = attributes
       curation_concern.date_modified = Date.today
-    end
-
-    def pid_for_object_to_copy_permissions_from
-      curation_concern.pid
     end
 
     def attach_file(generic_file, file_to_attach)

--- a/app/workers/delegate_editor_assign_worker.rb
+++ b/app/workers/delegate_editor_assign_worker.rb
@@ -1,0 +1,50 @@
+class DelegateEditorAssignWorker
+  class GrantError < RuntimeError
+
+    def initialize(url_string)
+      super(url_string)
+    end
+  end
+
+  def queue_name
+    :assign_delegate
+  end
+
+  attr_accessor :pids, :grantor, :grantee, :grantor_pid, :grantee_pid
+
+  def initialize(pids)
+    if pids[:grantor].nil?
+      raise GrantError.new("No Grantor found.")
+    end
+    if pids[:grantee].nil?
+      raise GrantError.new("No Grantee found.")
+    end
+    @grantor_pid = pids[:grantor]
+    @grantee_pid = pids[:grantee]
+  end
+
+  def run
+
+     grantor = ActiveFedora::Base.find(@grantor_pid, cast: true)
+     grantee = ActiveFedora::Base.find(@grantee_pid, cast: true)
+
+     type = [Article, Dataset, Document, GenericWork, Image]
+     type.each do |klass|
+       klass.find_each('edit_access_person_ssim' => grantor.email) do |work|
+           work.edit_users += [grantee.email]
+           work.save!
+           grantee = ActiveFedora::Base.find(grantee.pid, cast: true)
+           grantee.work_ids += [work.pid]
+           grantee.save!
+
+           if work.respond_to?(:generic_files)
+	     work.generic_files.each do |file|
+               file.edit_users = work.edit_users
+               file.edit_groups = work.edit_groups
+               file.save!
+             end    
+           end
+       end
+     end
+  end
+end

--- a/spec/controllers/curate/depositors_controller_spec.rb
+++ b/spec/controllers/curate/depositors_controller_spec.rb
@@ -7,6 +7,7 @@ describe Curate::DepositorsController do
   describe "as a logged in user" do
     before do
       sign_in person.user
+      Curate::DepositorsController#pids_for_delegate_assign.any_instance.stub(:person, :grantee)
     end
 
     describe "create" do
@@ -18,7 +19,11 @@ describe Curate::DepositorsController do
       it "should not add current user" do
         expect { post :create, person_id: person.id, grantee_id: person.id, format: 'json' }.to change{ Curate::ProxyDepositRights.count }.by(0)
         response.should be_success
-        response.body.should == "{}"
+        expect(response.body).to eq "{\"status\":\"ERROR\",\"code\":500}"
+      end
+
+      it 'should start a background worker' do
+        DelegateEditorAssignWorker.any_instance.stub(:run).and_return(true)
       end
 
     end

--- a/spec/services/curation_concern/base_actor_spec.rb
+++ b/spec/services/curation_concern/base_actor_spec.rb
@@ -35,6 +35,7 @@ describe CurationConcern::BaseActor do
         expect(curation_concern.depositor).to eq user.user_key
         expect(curation_concern.owner).to eq user.user_key
       end
+
     end
     context 'depositing on behalf of someone you have proxy access for' do
       subject {
@@ -60,12 +61,14 @@ describe CurationConcern::BaseActor do
     before do
       subject.stub(:apply_creation_data_to_curation_concern)
       subject.stub(:apply_save_data_to_curation_concern)
+      subject.stub(:apply_delegates_as_editor)
     end
 
     describe 'success' do
       it 'returns true' do
         subject.stub(:assign_remote_identifier_if_applicable).and_return(true)
         subject.stub(:apply_access_permissions).and_return(true)
+        subject.stub(:apply_delegates_as_editor).and_return(true)
         subject.create.should be_true
       end
     end

--- a/spec/services/curation_concern/generic_work_actor_spec.rb
+++ b/spec/services/curation_concern/generic_work_actor_spec.rb
@@ -64,6 +64,17 @@ describe CurationConcern::GenericWorkActor do
             expect(generic_file).to be_authenticated_only_access
           end
         end
+
+        describe 'AccessPermissionsCopyWorker' do
+          describe "#new" do
+            it "should accept ( :pid_for_object_to_copy_permissions_from ) as a parameter" do
+              expect { AccessPermissionsCopyWorker.new( :pid_for_object_to_copy_permissions_from ) }.to_not raise_error
+            end
+            it "should not accept ( :foo, :bar ) as parameters" do
+              expect { AccessPermissionsCopyWorker.new( :foo, :bar ) }.to raise_error
+            end
+          end
+        end
       end
 
       describe 'with multiple files file' do
@@ -87,7 +98,18 @@ describe CurationConcern::GenericWorkActor do
             expect(curation_concern).to be_authenticated_only_access
           end
         end
-      end
+  
+        describe 'AccessPermissionsCopyWorker' do
+          describe "#new" do
+            it "should accept ( :pid_for_object_to_copy_permissions_from ) as a parameter" do
+              expect { AccessPermissionsCopyWorker.new( :pid_for_object_to_copy_permissions_from ) }.to_not raise_error
+            end
+            it "should not accept ( :foo, :bar ) as parameters" do
+              expect { AccessPermissionsCopyWorker.new( :foo, :bar ) }.to raise_error
+            end
+          end
+        end
+      end    
 
       describe 'with linked resources' do
         let(:attributes) {
@@ -108,6 +130,17 @@ describe CurationConcern::GenericWorkActor do
             link = curation_concern.linked_resources.first
             expect(link.url).to eq 'http://www.youtube.com/watch?v=oHg5SJYRHA0'
             expect(curation_concern).to be_authenticated_only_access
+          end
+        end
+   
+         describe 'AccessPermissionsCopyWorker' do
+          describe "#new" do
+            it "should accept ( :pid_for_object_to_copy_permissions_from ) as a parameter" do
+              expect { AccessPermissionsCopyWorker.new( :pid_for_object_to_copy_permissions_from ) }.to_not raise_error
+            end
+            it "should not accept ( :foo, :bar ) as parameters" do
+              expect { AccessPermissionsCopyWorker.new( :foo, :bar ) }.to raise_error
+            end
           end
         end
       end
@@ -135,8 +168,18 @@ describe CurationConcern::GenericWorkActor do
             expect(curation_concern).to be_authenticated_only_access
           end
         end
-      end
 
+         describe 'AccessPermissionsCopyWorker' do
+          describe "#new" do
+            it "should accept ( :pid_for_object_to_copy_permissions_from ) as a parameter" do
+              expect { AccessPermissionsCopyWorker.new( :pid_for_object_to_copy_permissions_from ) }.to_not raise_error
+            end
+            it "should not accept ( :foo, :bar ) as parameters" do
+              expect { AccessPermissionsCopyWorker.new( :foo, :bar ) }.to raise_error
+            end
+          end
+        end
+      end
     end
 
     describe '#update' do

--- a/spec/services/curation_concern_spec.rb
+++ b/spec/services/curation_concern_spec.rb
@@ -40,16 +40,13 @@ describe CurationConcern do
     context "characterize" do
       let(:stub_deposit_job) { double }
       let(:stub_characterize_job) { double }
-      let(:stub_access_permissions_job) { double }
       before do
         Curate::ContentDepositEventJob.should_receive(:new).and_return(stub_deposit_job)
         CharacterizeJob.should_receive(:new).and_return(stub_characterize_job)
-        AccessPermissionsCopyWorker.should_receive(:new).with(curation_concern.pid).and_return(stub_access_permissions_job)
       end
       it 'should characterize' do
         Sufia.queue.should_receive(:push).with(stub_deposit_job).once
         Sufia.queue.should_receive(:push).with(stub_characterize_job).once
-        Sufia.queue.should_receive(:push).with(stub_access_permissions_job).once
         actor = CurationConcern.actor(generic_file, user, {batch_id: curation_concern.pid, file: file})
         actor.create
       end

--- a/spec/workers/delegate_editor_assign_worker_spec.rb
+++ b/spec/workers/delegate_editor_assign_worker_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe DelegateEditorAssignWorker do
+
+  let(:person) { FactoryGirl.create(:person_with_user) }
+  let(:user) { person.user }
+  let(:grantee) { FactoryGirl.create(:person_with_user) }
+  let(:another_user) { grantee.user }
+  let(:generic_work_w_condition) { FactoryGirl.create(:generic_work, depositor: user.email, user: user, edit_users: [user.email]) }
+  let(:generic_work_wo_condition) { FactoryGirl.create(:generic_work, user: user, owner: user.email) }
+  let(:pids) {{:grantor=>person.pid, :grantee=>grantee.pid}}
+  let(:nilpids) {{:grantee =>nil, :grantor =>nil}}
+
+  it 'should raise error when no grantor pid' do
+    expect{
+      DelegateEditorCleanupWorker.new(nilpids)
+    }.to raise_error( DelegateEditorCleanupWorker::GrantError )
+  end
+
+  it 'should raise error when no grantee pid' do
+    expect{
+      DelegateEditorCleanupWorker.new(nilpids)
+    }.to raise_error( DelegateEditorCleanupWorker::GrantError )
+  end
+
+
+  context 'for valid pid' do
+
+    it 'should assign edit access on qualified works' do
+      
+      expect(generic_work_w_condition.edit_users).not_to include (grantee.email)
+      
+      DelegateEditorAssignWorker.new(pids).run
+      
+      expect(generic_work_w_condition.reload.edit_users).to include (grantee.email)
+
+    end
+
+    it 'should not assign editor on unqualified works' do
+
+      expect(generic_work_wo_condition.edit_users).not_to eq [grantee.email]
+
+      DelegateEditorCleanupWorker.new(pids).run
+
+      expect(generic_work_wo_condition.edit_users).not_to eq [grantee.email]
+
+    end
+  
+  end
+end


### PR DESCRIPTION
...or

and modifies solr_helper to use edit_users as search index.

I had to move this method out of base actor due to the more
complex use of Delegate and Embargo.  The actions that govern
this functionality happen in the generic_works_actor, so the
permissions were not filtering down to the files attached.

The modification to the solr helper is to allow works to be
discoverable by both the depositor (delegate) and the owner.