### PR TITLE
Enable multifile html5 upload and refactor virus scanning to support multiple files

### DIFF
--- a/app/views/curation_concern/articles/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/articles/_form_files_and_links.html.erb
@@ -19,7 +19,7 @@
         <div id="my-tab-content" class="tab-content">
           <div class="tab-pane active" id="file">
             <fieldset>
-              <%= f.input :files, as: :file, label: 'Upload a file', hint: 'A PDF is preferred' %>
+              <%= f.input :files, as: :file, input_html: { multiple: true }, label: 'Upload a file', hint: 'A PDF is preferred. Hold Shift or Command to select multiple files' %>
             </fieldset>
           </div>
 

--- a/app/views/curation_concern/base/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/base/_form_files_and_links.html.erb
@@ -19,7 +19,7 @@
         <div id="my-tab-content" class="tab-content">
           <div class="tab-pane active" id="file">
             <fieldset>
-              <%= f.input :files, as: :file, label: 'Upload a file'%>
+              <%= f.input :files, as: :file, input_html: { multiple: true }, label: 'Upload a file', hint: "Hold Shift or Command to select multiple files" %>
             </fieldset>
           </div>
 


### PR DESCRIPTION
This begins to set the stage for more complicated file-upload work. It doesn't close the issue, but I feel it's worthwhile as a separate PR.