### PR TITLE
Remove the deactivate account button from user profile

### DIFF
--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -26,4 +26,4 @@
 
 <% end %>
 
-<%= render partial: 'registrations/form_account_deactivation', locals: { resource: resource } %>
+<%# render partial: 'registrations/form_account_deactivation', locals: { resource: resource } %>


### PR DESCRIPTION
We've decided to disable account deactivation for all users.  There was no existing test for the account deactivation feature.  So no tests needed to be removed.