### PR TITLE
Add permalinks to curation concerns

### DIFF
--- a/app/views/curation_concern/base/_permalink.html.erb
+++ b/app/views/curation_concern/base/_permalink.html.erb
@@ -1,0 +1,4 @@
+<% page = I18n.t('sufia.application_uri') + common_object_path(curation_concern.noid) %>
+<p>
+  Alternative link to this page: <%= link_to page, page %>
+</p>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -30,3 +30,4 @@
   <% end %>
 <% end %>
 
+<%= render 'permalink', curation_concern: curation_concern %>

--- a/app/views/curation_concern/generic_files/_permalink.html.erb
+++ b/app/views/curation_concern/generic_files/_permalink.html.erb
@@ -1,0 +1,4 @@
+<% page = I18n.t('sufia.application_uri') + common_object_path(curation_concern.noid) %>
+<p>
+  Alternative link to this page: <%= link_to page, page %>
+</p>

--- a/app/views/curation_concern/generic_files/show.html.erb
+++ b/app/views/curation_concern/generic_files/show.html.erb
@@ -12,3 +12,5 @@
     <% end %>
     <%= link_to "Back to #{parent.human_readable_type}", polymorphic_path([:curation_concern, parent]), class: 'btn btn-primary' %>
   </div>
+
+<%= render 'permalink', curation_concern: curation_concern %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -2,6 +2,7 @@ en:
   sufia:
     product_name:       "Curate"
     help_email:         "scholar@uc.edu"
+    application_uri:    "https://scholar.uc.edu"
     institution_name:   "Your Institution"
     institution_homepage_url:   "#"
     division_name:      "Your Division at Institution"

--- a/spec/views/curation_concern/base/_permalink.html.erb_spec.rb
+++ b/spec/views/curation_concern/base/_permalink.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'curation_concern/base/_permalink.html.erb' do
+  let(:curation_concern) { stub_model(GenericWork, pid: 'sufia:1234', noid: '1234') }
+  let(:path) { common_object_path(curation_concern.noid) }
+  let(:link) { I18n.t('sufia.application_uri') + path }
+
+  before do
+    render partial: 'permalink', locals: { curation_concern: curation_concern }
+  end
+
+  it 'it should display the link' do
+    expect(rendered).to have_link(link, link)
+  end
+end


### PR DESCRIPTION
Adds common_object_path (show) with application url to the bottom of each page. I'm not able to find an easy way to get the URL from the app, so I added it to the locales. Open to advice if anyone has a better option.

Here are screenshots from Curate:

![image](https://cloud.githubusercontent.com/assets/2651187/8461569/a8e51712-1ffb-11e5-888d-4120c8b908f4.png)

![image](https://cloud.githubusercontent.com/assets/2651187/8461579/be55a2c4-1ffb-11e5-9bdb-cebe9ad1d513.png)