### PR TITLE
Draft of object type manifest reports

### DIFF
--- a/app/services/collections_report.rb
+++ b/app/services/collections_report.rb
@@ -1,0 +1,17 @@
+class CollectionsReport < Report
+
+  private
+
+  def self.report_objects
+    Collection.all
+  end
+
+  def self.fields(collection = Collection.new)
+    [
+      { pid: collection.pid },
+      { title: collection.title },
+      { depositor: collection.depositor },
+      { works: collection.member_ids.join(" ") }
+    ]
+  end
+end

--- a/app/services/files_report.rb
+++ b/app/services/files_report.rb
@@ -1,0 +1,19 @@
+class FilesReport < Report
+
+  private
+
+  def self.report_objects
+    GenericFile.all
+  end
+
+  def self.fields(file = GenericFile.new)
+    [ 
+      { pid: file.pid },
+      { title: file.label },
+      { filename: file.filename },
+      { owner: file.owner },
+      { depositor: file.depositor },
+      { editors: file.edit_users.join(" ") },
+    ]
+  end
+end

--- a/app/services/groups_report.rb
+++ b/app/services/groups_report.rb
@@ -1,0 +1,17 @@
+class GroupsReport < Report
+
+  private
+
+  def self.report_objects
+    Hydramata::Group.all
+  end
+
+  def self.fields(group = Hydramata::Group.new)
+    [
+      { pid: group.pid },
+      { title: group.title },
+      { depositor: group.depositor }, 
+      { members: group.member_ids.join(" ") }
+    ]
+  end
+end

--- a/app/services/linked_resources_report.rb
+++ b/app/services/linked_resources_report.rb
@@ -1,0 +1,16 @@
+class LinkedResourcesReport < Report
+
+  private
+
+  def self.report_objects
+    LinkedResource.all
+  end
+
+  def self.fields(resource = LinkedResource.new)
+    [ 
+      { pid: resource.pid },
+      { owner: resource.owner },
+      { depositor: resource.depositor },
+    ]
+  end
+end

--- a/app/services/people_report.rb
+++ b/app/services/people_report.rb
@@ -1,0 +1,21 @@
+class PeopleReport < Report
+
+  private
+
+  def self.report_objects
+    Person.all
+  end
+
+  def self.fields(person = Person.new)
+    [
+      { pid: person.pid },
+      { depositor: person.depositor }, 
+      { email: person.email }, 
+      { delegates: delegate_emails(person) }
+    ]
+  end
+
+  def self.delegate_emails(person)
+    (person.user.can_receive_deposits_from.collect { |d| d.email }).join(" ") unless person.user.nil?
+  end
+end

--- a/app/services/report.rb
+++ b/app/services/report.rb
@@ -1,0 +1,30 @@
+class Report
+  require 'csv'
+
+  def self.report_location
+    [Rails.root, 'vendor', report_title].join('/')
+  end
+
+  def self.create_report
+    CSV.open(report_location, "w", options = { col_sep: "\t" }) do |csv|
+      csv << report_header
+      report_objects.each do |object|
+        csv << report_row(object)
+      end
+    end
+  end
+
+  private
+
+  def self.report_title
+    self.name.underscore + '.csv'
+  end
+
+  def self.report_header
+    fields.collect { |field| field.keys[0] }   
+  end
+
+  def self.report_row(object)
+    fields(object).collect { |field| field.values[0] }   
+  end
+end

--- a/app/services/works_report.rb
+++ b/app/services/works_report.rb
@@ -1,0 +1,27 @@
+class WorksReport < Report
+
+  private
+
+  def self.report_objects
+    works = Array.new
+    work_type_classes.each do |type_class|
+      type_class.all.each { |work| works << work }
+    end
+    works
+  end
+
+  def self.fields(work = GenericWork.new)
+    [
+      { pid: work.pid },
+      { title: work.title },
+      { owner: work.owner },
+      { depositor: work.depositor },
+      { editors: work.editor_ids.join(" ") },
+      { editor_groups: work.editor_group_ids.join(" ") }
+    ]
+  end
+
+  def self.work_type_classes
+    Curate.configuration.registered_curation_concern_types.collect { |type| type.constantize }
+  end
+end

--- a/lib/tasks/manifest.rake
+++ b/lib/tasks/manifest.rake
@@ -1,0 +1,29 @@
+namespace :manifest do
+  desc "Run all manifest reports"
+  task :all => [:works, :files, :people, :collections, :groups, :linked_resources] do
+  end
+
+  task :works => :environment do
+    WorksReport.create_report
+  end
+
+  task :files => :environment do
+    FilesReport.create_report
+  end
+
+  task :people => :environment do
+    PeopleReport.create_report
+  end
+
+  task :collections => :environment do
+    CollectionsReport.create_report
+  end
+
+  task :groups => :environment do
+    GroupsReport.create_report
+  end
+
+  task :linked_resources => :environment do
+    LinkedResourcesReport.create_report
+  end
+end

--- a/spec/services/collections_report_spec.rb
+++ b/spec/services/collections_report_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe CollectionsReport do
+  describe '#report_location' do
+    it 'should be vendor/collections_report.csv' do
+      expect(CollectionsReport.report_location).to eq("#{Rails.root}/vendor/collections_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_collections) { [ 
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['pid', 'pid']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['pid']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['']),
+      FakeCollection.new('pid', 'title', 'foo@bar.org', ['pid', 'pid']) 
+    ] }
+
+    before(:each) do
+      Collection.stub(:all).and_return(fake_collections)
+
+      File.delete(CollectionsReport.report_location) if File.exist?(CollectionsReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      CollectionsReport.create_report
+      expect(File).to exist(CollectionsReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      CollectionsReport.create_report
+      expect(
+        File.open(CollectionsReport.report_location).readlines.size
+      ).to eq(fake_collections.length + 1)
+    end
+
+    class FakeCollection < Struct.new(:pid, :title, :depositor, :member_ids)
+    end
+  end
+end

--- a/spec/services/files_report_spec.rb
+++ b/spec/services/files_report_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe FilesReport do
+  describe '#report_location' do
+    it 'should be vendor/files_report.csv' do
+      expect(FilesReport.report_location).to eq("#{Rails.root}/vendor/files_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_files) { [ 
+      FakeFile.new('pid', 'title', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid']),
+      FakeFile.new('pid', 'title', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['']),
+      FakeFile.new('pid', 'title', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['pid']),
+      FakeFile.new('pid', 'title', 'file.pdf', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid']),
+    ] }
+
+    before(:each) do
+      GenericFile.stub(:all).and_return(fake_files)
+
+      File.delete(FilesReport.report_location) if File.exist?(FilesReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      FilesReport.create_report
+      expect(File).to exist(FilesReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      FilesReport.create_report
+      expect(
+        File.open(FilesReport.report_location).readlines.size
+      ).to eq(fake_files.length + 1)
+    end
+
+    class FakeFile < Struct.new(:pid, :label, :filename, :owner, :depositor, :edit_users)
+    end
+  end
+end

--- a/spec/services/groups_report_spec.rb
+++ b/spec/services/groups_report_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe GroupsReport do
+  describe '#report_location' do
+    it 'should be vendor/groups_report.csv' do
+      expect(GroupsReport.report_location).to eq("#{Rails.root}/vendor/groups_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_groups) { [ 
+      FakeGroup.new('pid', 'title', 'foo@bar.org', ['pid', 'pid']),
+      FakeGroup.new('pid', 'title', 'foo@bar.org', ['pid']),
+      FakeGroup.new('pid', 'title', 'foo@bar.org', ['']),
+      FakeGroup.new('pid', 'title', 'foo@bar.org', ['pid', 'pid']) 
+    ] }
+
+    before(:each) do
+      Hydramata::Group.stub(:all).and_return(fake_groups)
+
+      File.delete(GroupsReport.report_location) if File.exist?(GroupsReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      GroupsReport.create_report
+      expect(File).to exist(GroupsReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      GroupsReport.create_report
+      expect(
+        File.open(GroupsReport.report_location).readlines.size
+      ).to eq(fake_groups.length + 1)
+    end
+
+    class FakeGroup < Struct.new(:pid, :title, :depositor, :member_ids)
+    end
+  end
+end

--- a/spec/services/linked_resource_report_spec.rb
+++ b/spec/services/linked_resource_report_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe LinkedResourcesReport do
+  describe '#report_location' do
+    it 'should be vendor/linked_resources_report.csv' do
+      expect(LinkedResourcesReport.report_location).to eq("#{Rails.root}/vendor/linked_resources_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_linked_resources) { [ 
+      FakeLinkedResource.new('pid', 'foo@bar.org', 'foo@bar.org'),
+      FakeLinkedResource.new('pid', 'foo@bar.org', 'foo@bar.org'),
+      FakeLinkedResource.new('pid', 'foo@bar.org', 'foo@bar.org'),
+      FakeLinkedResource.new('pid', 'foo@bar.org', 'foo@bar.org')
+    ] }
+
+    before(:each) do
+      LinkedResource.stub(:all).and_return(fake_linked_resources)
+
+      File.delete(LinkedResourcesReport.report_location) if File.exist?(LinkedResourcesReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      LinkedResourcesReport.create_report
+      expect(File).to exist(LinkedResourcesReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      LinkedResourcesReport.create_report
+      expect(
+        File.open(LinkedResourcesReport.report_location).readlines.size
+      ).to eq(fake_linked_resources.length + 1)
+    end
+
+    class FakeLinkedResource < Struct.new(:pid, :owner, :depositor)
+    end
+  end
+end

--- a/spec/services/people_report_spec.rb
+++ b/spec/services/people_report_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe PeopleReport do
+  describe '#report_location' do
+    it 'should be vendor/people_report.csv' do
+      expect(PeopleReport.report_location).to eq("#{Rails.root}/vendor/people_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_people) { [ 
+      FakePerson.new('pid', 'foo@bar.org', 'foo@bar.org', FakeUser.new([FakeDelegate.new('foo@bar.org')])),
+    ] }
+
+    before(:each) do
+      Person.stub(:all).and_return(fake_people)
+
+      File.delete(PeopleReport.report_location) if File.exist?(PeopleReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      PeopleReport.create_report
+      expect(File).to exist(PeopleReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      PeopleReport.create_report
+      expect(
+        File.open(PeopleReport.report_location).readlines.size
+      ).to eq(fake_people.length + 1)
+    end
+
+    class FakePerson < Struct.new(:pid, :depositor, :email, :user)
+    end
+
+    class FakeUser < Struct.new(:can_receive_deposits_from)
+    end
+
+    class FakeDelegate < Struct.new(:email)
+    end
+  end
+end

--- a/spec/services/works_report_spec.rb
+++ b/spec/services/works_report_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe WorksReport do
+  describe '#report_location' do
+    it 'should be vendor/work_report.csv' do
+      expect(WorksReport.report_location).to eq("#{Rails.root}/vendor/works_report.csv")
+    end
+  end
+
+  describe '#create_report' do
+    let(:fake_articles) { 
+      [ 
+        FakeWork.new('pid:1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], ['pid']),
+        FakeWork.new('pid:1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid'], ['pid'])
+      ]
+    }
+    let(:fake_generic_works) { [] }
+    let(:fake_images) { 
+      [ 
+        FakeWork.new('pid:1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], ['pid']),
+        FakeWork.new('pid:1234', 'Title', 'foo@bar.org', 'foo@bar.org', [''], ['pid']) 
+      ] 
+    }
+    let(:fake_datasets) { 
+      [ 
+        FakeWork.new('pid:1234', 'Title', 'foo@bar.org', 'foo@bar.org', ['pid', 'pid'], [''])
+      ]
+    }
+    let(:fake_documents) { [] }
+
+    before(:each) do
+      Article.stub(:all).and_return(fake_articles)
+      GenericWork.stub(:all).and_return(fake_generic_works)
+      Image.stub(:all).and_return(fake_images)
+      Dataset.stub(:all).and_return(fake_datasets)
+      Document.stub(:all).and_return(fake_documents)
+
+      File.delete(WorksReport.report_location) if File.exist?(WorksReport.report_location)
+    end
+
+    it 'should create a report in the report_location' do
+      WorksReport.create_report
+      expect(File).to exist(WorksReport.report_location) 
+    end
+
+    it 'should create a report one line longer than the number of objects reported on' do
+      WorksReport.create_report
+      expect(
+        File.open(WorksReport.report_location).readlines.size
+      ).to eq(
+        (fake_articles + fake_generic_works + fake_images + fake_datasets + fake_documents).length + 1)
+    end
+
+    class FakeWork < Struct.new(:pid, :title, :owner, :depositor, :editor_ids, :editor_group_ids)
+    end
+  end
+end


### PR DESCRIPTION
Classes and specs to produce simple CSV inventories of several object types:

* Collections
* People (including delegates)
* Works 
* Linked Resources
* Files
* Groups

Down the line these will probably turn into models for some sort of Repository-Manager-Accessible content dashboard, but these will help with the migration.

We should be able to just copy & paste the code below onto the Rails console in production to produce the documents during our migration work.