### PR TITLE
Add dc.identifier meta tag to Work show page

### DIFF
--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -42,6 +42,12 @@ module CurateHelper
     construct_page_title(text)
   end
 
+  def curation_concern_dublin_core_meta_tags(curation_concern)
+    meta_tags = Array.new
+    meta_tags << "<meta name='dc.identifier' content='#{curation_concern.identifier}'/>" unless curation_concern.identifier.blank?
+    meta_tags.join("\n").html_safe
+  end
+
   # options[:include_empty]
   def curation_concern_attribute_to_html(curation_concern, method_name, label = nil, options = {})
     markup = ""

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :dublin_core_meta_tags, curation_concern_dublin_core_meta_tags(curation_concern) %>
 <% content_for :page_title, curation_concern_page_title(curation_concern) %>
 <% content_for :page_header do %>
   <h1><%= curation_concern %> <span class="human_readable_type">(<%= curation_concern.human_readable_type %>)</span></h1>

--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -6,6 +6,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <%= yield(:dublin_core_meta_tags) if content_for?(:dublin_core_meta_tags) %>
     <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
     <meta name="viewport" content="width=device-width">
     <%= csrf_meta_tag %>

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'meta tags' do
+  describe 'dublin core' do
+    before(:all) do
+      generic_work = FactoryGirl.create(:public_generic_work,
+        identifier: 'doi:foo1bar2')
+      visit curation_concern_generic_work_path(generic_work)
+    end
+
+    it 'displays identifier' do
+      tag_label = 'dc.identifier'
+      tag_value = 'doi:foo1bar2'
+      tag = "meta[name='#{tag_label}'][content='#{tag_value}']"
+
+      expect(page).to have_css(tag, visible: false)
+    end
+  end
+end

--- a/spec/helpers/curate_helper_spec.rb
+++ b/spec/helpers/curate_helper_spec.rb
@@ -40,6 +40,24 @@ describe ApplicationHelper do
     )
   end
 
+  describe '#curation_concern_dublin_core_meta_tags' do
+    describe 'identifier' do
+      let(:identifier_content) { 'doi:foo1bar2' }
+      let(:identifier_meta_tag_name) { 'dc.identifier' }
+      let(:identifier_meta_tag) { "<meta name='#{ identifier_meta_tag_name }' content='#{ identifier_content }'/>" }
+      let(:work_with_identifier) { double(identifier: identifier_content) }
+      let(:work_without_identifer) { double(identifier: '') }
+
+      it 'should return meta tag if the identifer is present' do
+        expect(helper.curation_concern_dublin_core_meta_tags(work_with_identifier)).to include(identifier_meta_tag)
+      end
+
+      it 'should not return meta tag if the identifer is not present' do
+        expect(helper.curation_concern_dublin_core_meta_tags(work_without_identifer)).to_not include (identifier_meta_tag_name)
+      end
+    end
+  end
+
   describe '#curation_concern_attribute_to_html' do
     def render_curation_concern_attribute_html(expected_label, *item_or_collection)
       collection = Array(item_or_collection).flatten.compact


### PR DESCRIPTION
Partially addresses https://github.com/uclibs/scholar_uc/issues/342 by exposing the Work identifier (i.e., doi) as the Dublin Core identifier meta tag.