### PR TITLE
Add <legend> tags to all <fieldset> tags

### DIFF
--- a/app/views/curate/collections/_form_to_add_member.html.erb
+++ b/app/views/curate/collections/_form_to_add_member.html.erb
@@ -3,6 +3,7 @@
 
 <%= form_tag add_member_collections_path, method: :put do %>
   <fieldset class="required <%= fieldset_class %>">
+    <legend>Add this work to a collection</legend>
     <%= hidden_field_tag :collectible_id, collectible.pid %>
 
     <div class="control-group collection_id">

--- a/app/views/curation_concern/articles/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/articles/_form_files_and_links.html.erb
@@ -19,18 +19,21 @@
         <div id="my-tab-content" class="tab-content">
           <div class="tab-pane active" id="file">
             <fieldset>
+              <legend>Upload a file</legend>
               <%= f.input :files, as: :file, input_html: { multiple: true }, label: 'Upload a file', hint: 'A PDF is preferred. Hold Shift or Command to select multiple files' %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="link">
             <fieldset>
+              <legend>Add an external link</legend>
               <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="cloud">
             <fieldset>
+              <legend>Upload remote files</legend>
               <p id="status"></p>
               <%= hidden_field_tag :cloud_resource_urls, nil, class: 'cloud_resource' %>
               <%= button_tag("Click here to upload remote files", type: 'button', class: 'btn btn-large btn-success', id: "browse",

--- a/app/views/curation_concern/base/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/base/_form_files_and_links.html.erb
@@ -19,18 +19,21 @@
         <div id="my-tab-content" class="tab-content">
           <div class="tab-pane active" id="file">
             <fieldset>
+              <legend>Upload a file</legend>
               <%= f.input :files, as: :file, input_html: { multiple: true }, label: 'Upload a file', hint: "Hold Shift or Command to select multiple files" %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="link">
             <fieldset>
+              <legend>Add an external link</legend>
               <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="cloud">
             <fieldset>
+              <legend>Upload a remote file</legend>
               <p id="status"></p>
               <%= hidden_field_tag :cloud_resource_urls, nil, class: 'cloud_resource' %>
               <%= button_tag("Click here to upload remote files", type: 'button', class: 'btn btn-large btn-success', id: "browse",

--- a/app/views/curation_concern/base/_linked_editors.html.erb
+++ b/app/views/curation_concern/base/_linked_editors.html.erb
@@ -1,4 +1,5 @@
 <fieldset id="set-editors">
+  <legend>Set the editors of this work</legend>
   <% label ||= 'Editors' %>
   <div class="control-group required link-users" id="editors">
     <span class="control-label">

--- a/app/views/curation_concern/base/_linked_groups.html.erb
+++ b/app/views/curation_concern/base/_linked_groups.html.erb
@@ -1,4 +1,5 @@
 <fieldset id="set-groups">
+  <legend>Set the groups for this work</legend>
   <% label ||= 'Groups' %>
   <div class="control-group required link-groups" id="groups">
     <span class="control-label">

--- a/app/views/curation_concern/documents/_form_files_and_links.html.erb
+++ b/app/views/curation_concern/documents/_form_files_and_links.html.erb
@@ -19,18 +19,21 @@
         <div id="my-tab-content" class="tab-content">
           <div class="tab-pane active" id="file">
             <fieldset>
+              <legend>Upload a file</legend>
               <%= f.input :files, as: :file, input_html: { multiple: true }, label: 'Upload a file', hint: 'A PDF is preferred. Hold Shift or Command to select multiple files' %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="link">
             <fieldset>
+              <legend>Add an external link</legend>
               <%= f.input :linked_resource_urls, label: "External link", input_html: {class: 'input-xlarge'} %>
             </fieldset>
           </div>
 
           <div class="tab-pane" id="cloud">
             <fieldset>
+              <legend>Upload a remote file></legend>
               <p id="status"></p>
               <%= hidden_field_tag :cloud_resource_urls, nil, class: 'cloud_resource' %>
               <%= button_tag("Click here to upload remote files", type: 'button', class: 'btn btn-large btn-success', id: "browse",

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -1,4 +1,5 @@
 <% label ||= 'Members' %>
+<legend>Edit Group Members</legend>
 <div class="control-group required link-users" id="members">
   <div class="row">
     <div class="span4">


### PR DESCRIPTION
This satisfies the accessibility scan rule that all fieldset tags should be followed by a legend tag.  No tests are needed within our app because the accessibility scan will determine if the accessibility standards are being followed.