### PR TITLE
Correct delegate/editor assignment on work creation

### DIFF
--- a/app/services/curation_concern/base_actor.rb
+++ b/app/services/curation_concern/base_actor.rb
@@ -35,7 +35,6 @@ module CurationConcern
       apply_depositor_metadata
       apply_owner_metadata
       apply_deposit_date
-      apply_delegates_as_editor
     end
 
     def apply_update_data_to_curation_concern
@@ -78,11 +77,11 @@ module CurationConcern
       owner = owner_from_attributes || user
       curation_concern.edit_users += [owner.user_key]
       curation_concern.owner = owner.user_key
+      apply_delegates_as_editor(owner)
     end
 
-    def apply_delegates_as_editor
-      owner = owner_from_attributes || user
-      user.can_receive_deposits_from.each do |delegate|
+    def apply_delegates_as_editor(owner)
+      owner.can_receive_deposits_from.each do |delegate|
         curation_concern.edit_users += [delegate.user_key]        
       end
     end

--- a/spec/services/curation_concern/base_actor_spec.rb
+++ b/spec/services/curation_concern/base_actor_spec.rb
@@ -26,8 +26,10 @@ describe CurationConcern::BaseActor do
 
   describe 'apply_creation_data_to_curation_concern' do
     let(:proxy_user) { FactoryGirl.create(:user) }
+    let(:proxys_proxy_user) { FactoryGirl.create(:user) }
     before do
       user.can_receive_deposits_from << proxy_user
+      proxy_user.can_receive_deposits_from << proxys_proxy_user
       subject.send(:apply_creation_data_to_curation_concern)
     end
     context 'depositing for yourself' do
@@ -46,6 +48,7 @@ describe CurationConcern::BaseActor do
         expect(curation_concern.depositor).to eq proxy_user.user_key
         expect(curation_concern.owner).to eq user.user_key
         expect(curation_concern.edit_users).to include(user.user_key, proxy_user.user_key)
+        expect(curation_concern.edit_users.length).to eq 2
       end
     end
     context 'depositing on behalf of someone you do not have proxy access for' do


### PR DESCRIPTION
This should close https://github.com/uclibs/scholar_uc/issues/499

The current user's delegates were being assigned as edit users on work creation - now only the owners delegates should.

I confirmed that the spec I added (line 51 of the spec) failed (with 3) before making the change in the actor.
